### PR TITLE
Fix some linter errors

### DIFF
--- a/deps/zlib/contrib/minizip/unzip.c
+++ b/deps/zlib/contrib/minizip/unzip.c
@@ -1247,7 +1247,7 @@ extern int ZEXPORT unzReadCurrentFile  (file, buf, len)
         return UNZ_PARAMERROR;
 
 
-    if ((pfile_in_zip_read_info->read_buffer == NULL))
+    if (pfile_in_zip_read_info->read_buffer == NULL)
         return UNZ_END_OF_LIST_OF_FILE;
     if (len==0)
         return 0;

--- a/deps/zlib/contrib/minizip/zip.c
+++ b/deps/zlib/contrib/minizip/zip.c
@@ -193,13 +193,6 @@ local void init_linkedlist(ll)
     ll->first_block = ll->last_block = NULL;
 }
 
-local void free_linkedlist(ll)
-    linkedlist_data* ll;
-{
-    free_datablock(ll->first_block);
-    ll->first_block = ll->last_block = NULL;
-}
-
 
 local int add_data_in_datablock(ll,buf,len)
     linkedlist_data* ll;
@@ -762,9 +755,9 @@ extern int ZEXPORT zipOpenNewFileInZip3 (file, filename, zipfi,
     zi->ci.flag = 0;
     if ((level==8) || (level==9))
       zi->ci.flag |= 2;
-    if ((level==2))
+    if (level==2)
       zi->ci.flag |= 4;
-    if ((level==1))
+    if (level==1)
       zi->ci.flag |= 6;
     if (password != NULL)
       zi->ci.flag |= 1;


### PR DESCRIPTION
Remove unused function and extraneous parentheses wich causes some extra logs during npm install.
